### PR TITLE
Allow running in namespaces and with tf_prefix

### DIFF
--- a/params/ekf_params.yaml
+++ b/params/ekf_params.yaml
@@ -59,7 +59,7 @@ world_frame: odom           # Defaults to the value of odom_frame if unspecified
 # sensor_msgs/Imu). To add an input, simply append the next number in the sequence to its "base" name, e.g., odom0,
 # odom1, twist0, twist1, imu0, imu1, imu2, etc. The value should be the topic name. These parameters obviously have no
 # default values, and must be specified.
-odom0: /odom/wheel
+odom0: odom/wheel
 
 # Each sensor reading updates some or all of the filter's state. These options give you greater control over which
 # values from each measurement are fed to the filter. For example, if you have an odometry message as input, but only
@@ -109,7 +109,7 @@ odom0_relative: true
 #odom0_twist_rejection_threshold: 1
 
 # values is x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az
-imu0: /imu                     #-----------------------------------------
+imu0: imu                     #-----------------------------------------
 imu0_config: [false, false, false,
               false, false, true,
               false, false, false,

--- a/src/msgs_conversion.cpp
+++ b/src/msgs_conversion.cpp
@@ -1,5 +1,5 @@
 #include "ros/ros.h"
-#include "rosbot_ekf_custom/Imu.h"       
+#include "rosbot_ekf/Imu.h"       
 #include "geometry_msgs/PoseStamped.h"
 #include "sensor_msgs/Imu.h"
 #include "nav_msgs/Odometry.h"
@@ -48,7 +48,7 @@ void poseCallback(const geometry_msgs::PoseStamped &pose_msg)
 
 }
 
-void mpuCallback(const rosbot_ekf_custom::Imu &mpu_msg)
+void mpuCallback(const rosbot_ekf::Imu &mpu_msg)
 {
   sensor_msgs::Imu imu_msg;
   


### PR DESCRIPTION
Allow msgs_conversion to be run in a namespace, accepting /namespace/pose and /namespace/mpu9250 as input and publishing to  /namespace/odom/wheel and /namespace/imu.

Use tf_prefix parameter to set the frame_id to /namespace/imu_link and /namespace/odom.

This will make running multiple ROSbots possible.